### PR TITLE
Improve performance with caching and parallelized data loading

### DIFF
--- a/custom-front-end/src/SupportHomeView.cs
+++ b/custom-front-end/src/SupportHomeView.cs
@@ -9,11 +9,15 @@ using Mosaik.Helpers;
 using Mosaik.Components.Nodes;
 using Mosaik.Components;
 using Mosaik.Schema;
+using System.Collections.Generic;
 
 namespace TechnicalSupport.FrontEnd
 {
     public class SupportHomeView : IComponent
     {
+        private static readonly Dictionary<string, string> DeviceNameByCaseUid = new Dictionary<string, string>();
+        private static readonly Dictionary<string, List<Action<string>>> PendingDeviceNameRequestsByCaseUid = new Dictionary<string, List<Action<string>>>();
+
         private IComponent _container;
         public SupportHomeView(Parameters state)
         {
@@ -40,13 +44,7 @@ namespace TechnicalSupport.FrontEnd
             var isClosed = sh.Node.GetString(N.SupportCase.Status) == "Closed";
             var prodName = TextBlock().SemiBold().Tiny().W(10).Grow().Secondary().Ellipsis();
 
-            Mosaik.API.Aggregated.GetNodeNeighbors(sh.Node.UID, N.Device.Type, E.ForDevice, (uid) =>
-            {
-                Mosaik.API.Aggregated.GetNode(uid[0], n =>
-                {
-                    prodName.Text = n.GetString("Name");
-                });
-            });
+            ResolveDeviceName(sh.Node.UID, deviceName => prodName.Text = deviceName);
 
             var title = TextBlock(sh.Node.GetString(N.SupportCase.Summary)).SemiBold().W(10).Grow().TextLeft().ML(16).NoWrap().Ellipsis();
 
@@ -65,6 +63,53 @@ namespace TechnicalSupport.FrontEnd
             btn.OnClick(() => NodePreview.For(sh.Node));
 
             return new ReplacedResult(btn, rr);
+        }
+
+        private static void ResolveDeviceName(string supportCaseUid, Action<string> onResolved)
+        {
+            if (DeviceNameByCaseUid.TryGetValue(supportCaseUid, out var cachedDeviceName))
+            {
+                onResolved(cachedDeviceName);
+                return;
+            }
+
+            if (PendingDeviceNameRequestsByCaseUid.TryGetValue(supportCaseUid, out var pendingCallbacks))
+            {
+                pendingCallbacks.Add(onResolved);
+                return;
+            }
+
+            PendingDeviceNameRequestsByCaseUid[supportCaseUid] = new List<Action<string>>() { onResolved };
+
+            Mosaik.API.Aggregated.GetNodeNeighbors(supportCaseUid, N.Device.Type, E.ForDevice, uids =>
+            {
+                if (uids.Length == 0)
+                {
+                    CompleteDeviceNameRequest(supportCaseUid, "Unknown device");
+                    return;
+                }
+
+                Mosaik.API.Aggregated.GetNode(uids[0], node =>
+                {
+                    CompleteDeviceNameRequest(supportCaseUid, node.GetString(N.Device.Name));
+                });
+            });
+        }
+
+        private static void CompleteDeviceNameRequest(string supportCaseUid, string deviceName)
+        {
+            DeviceNameByCaseUid[supportCaseUid] = deviceName;
+
+            if (!PendingDeviceNameRequestsByCaseUid.TryGetValue(supportCaseUid, out var pendingCallbacks))
+            {
+                return;
+            }
+
+            PendingDeviceNameRequestsByCaseUid.Remove(supportCaseUid);
+            foreach (var callback in pendingCallbacks)
+            {
+                callback(deviceName);
+            }
         }
 
         public dom.HTMLElement Render() => _container.Render();


### PR DESCRIPTION
### Motivation

- Reduce redundant UI/API calls when support-case cards rerender and avoid repeated chat-context fetches for the same chat to improve responsiveness. 
- Speed up data-connector startup by doing independent I/O and schema calls in parallel to reduce total ingestion time.

### Description

- Add client-side device-name caching and in-flight request coalescing in `custom-front-end/src/SupportHomeView.cs` via `DeviceNameByCaseUid`, `PendingDeviceNameRequestsByCaseUid`, `ResolveDeviceName` and `CompleteDeviceNameRequest` so multiple renders for the same support-case UID reuse a single neighbor/node lookup instead of issuing duplicate `Mosaik.API.Aggregated.GetNodeNeighbors`/`GetNode` calls.
- Add chat-context caching in `custom-front-end/src/SupportChat.cs` via `ContextByChatUid`, change `LoadOrInitializeContextForChatAsync` to reuse in-flight `Task<SupportChatContext>`s and store resolved contexts so repeated `support-chat/get-context` and `support-chat/set-context` interactions avoid unnecessary endpoint calls.
- Parallelize independent operations in the data connector (`data-connector/src/App.cs`) by calling node-schema creation with `Task.WhenAll`, and read the JSON datasets in parallel using `LoadJsonAsync<T>` plus `Task.WhenAll` before ingesting, and centralize file reads in the new `LoadJsonAsync<T>` helper.

### Testing

- Attempted `dotnet build TechnicalSupport.sln`, but the command failed in this environment because `dotnet` is not installed (automated check returned `command not found`).
- Verified changes with `git diff` and `git status` and committed the patch (`git commit` succeeded). 
- Retrieved the new commit id with `git rev-parse --short HEAD` to confirm the changes were recorded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699e34dca878832cb4c3e6884f6ed18d)